### PR TITLE
Use a render function instead of a template, fix #19

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,18 @@ var createComponent = function(Vue, tagName, chartType) {
   ]
   Vue.component(tagName, {
     props: ["data", "id", "width", "height"].concat(chartProps),
-    template: '<div v-bind:id="chartId" v-bind:style="chartStyle">Loading...</div>',
+    render: function(createElement) {
+      return createElement(
+        "div",
+        {
+          attrs: {
+            id: this.chartId
+          },
+          style: this.chartStyle
+        },
+        ["Loading..."]
+      );
+    },
     data: function() {
       return {
         chartId: null


### PR DESCRIPTION
When using vue-cli, people can choose between runtime-only and compiler+runtime. In runtime-only configuration, template can only be used in `.vue` file.

This should fix #19 also.