### PR TITLE
avoid not needed updates for the chart, when dom element changes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,8 +61,13 @@ let createComponent = function(Vue, tagName, chartType) {
     mounted: function() {
       this.chart = new chartType(this.chartId, this.data, this.chartOptions)
     },
-    updated: function() {
-      this.chart.updateData(this.data, this.chartOptions)
+    watch: {
+      data: {
+        handler: function() {
+          this.chart.updateData(this.data, this.chartOptions)
+        },
+        deep: true
+      }
     }
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -62,11 +62,8 @@ let createComponent = function(Vue, tagName, chartType) {
       this.chart = new chartType(this.chartId, this.data, this.chartOptions)
     },
     watch: {
-      data: {
-        handler: function() {
-          this.chart.updateData(this.data, this.chartOptions)
-        },
-        deep: true
+      data: function() {
+        this.chart.updateData(this.data, this.chartOptions)
       }
     }
   })

--- a/src/index.js
+++ b/src/index.js
@@ -56,15 +56,15 @@ let createComponent = function(Vue, tagName, chartType) {
       }
     },
     created: function() {
-      this.chartId = this.chartId || this.id || ("chart-" + chartId++)
+      this.chartId = this.chartId || this.id || ("chart-" + chartId++);
+      ['data'].concat(chartProps).forEach((property) => {
+        this.$watch(property, function () {
+          this.chart.updateData(this.data, this.chartOptions);
+        }, { deep: true });
+      });
     },
     mounted: function() {
       this.chart = new chartType(this.chartId, this.data, this.chartOptions)
-    },
-    watch: {
-      data: function() {
-        this.chart.updateData(this.data, this.chartOptions)
-      }
     }
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -56,12 +56,12 @@ let createComponent = function(Vue, tagName, chartType) {
       }
     },
     created: function() {
-      this.chartId = this.chartId || this.id || ("chart-" + chartId++);
+      this.chartId = this.chartId || this.id || ("chart-" + chartId++)
       ['data'].concat(chartProps).forEach((property) => {
         this.$watch(property, function () {
-          this.chart.updateData(this.data, this.chartOptions);
-        }, { deep: true });
-      });
+          this.chart.updateData(this.data, this.chartOptions)
+        }, { deep: true })
+      })
     },
     mounted: function() {
       this.chart = new chartType(this.chartId, this.data, this.chartOptions)

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ let createComponent = function(Vue, tagName, chartType) {
     },
     created: function() {
       this.chartId = this.chartId || this.id || ("chart-" + chartId++)
-      let props = ['data'].concat(chartProps)
+      const props = ['data'].concat(chartProps)
       props.forEach((property) => {
         this.$watch(property, function () {
           this.chart.updateData(this.data, this.chartOptions)

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,8 @@ let createComponent = function(Vue, tagName, chartType) {
     },
     created: function() {
       this.chartId = this.chartId || this.id || ("chart-" + chartId++)
-      ['data'].concat(chartProps).forEach((property) => {
+      let props = ['data'].concat(chartProps)
+      props.forEach((property) => {
         this.$watch(property, function () {
           this.chart.updateData(this.data, this.chartOptions)
         }, { deep: true })


### PR DESCRIPTION
When using animation like in this example

`<pie-chart :title="'Anteile an den Gesamtausgaben'" :data="openAccessBarometer.costsPublisher"
                   thousands="." decimal="," legend="right" :suffix="openAccessBarometer.relative ? '%' : '€'"
                   :library="{animation: {duration: 1000}}"
                   download="true" :messages="{empty: 'Keine Daten verfügbar.'}"></pie-chart>`

you will see that every change in the dom creates a repaint of the chart. This is done in the updated method of the chart. Change it to a watcher on the data and everything is fine. 